### PR TITLE
chore(deps): bump dependency versions

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,3 +3,4 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [PSIServices/eas-healthchecks](https://github.com/PSIServices/eas-healthchecks.git) |  | []() | 
+[PSIServices/eas-selt-sqlserver](https://github.com/PSIServices/eas-selt-sqlserver.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,4 +3,4 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [PSIServices/eas-healthchecks](https://github.com/PSIServices/eas-healthchecks.git) |  | []() | 
-[PSIServices/eas-parent-pom](https://github.com/PSIServices/eas-parent-pom.git) |  | []() | 
+[PSIServices/eas-candidate-attendance-service](https://github.com/PSIServices/eas-candidate-attendance-service.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,4 +3,4 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [PSIServices/eas-healthchecks](https://github.com/PSIServices/eas-healthchecks.git) |  | []() | 
-[PSIServices/eas-urn-service](https://github.com/PSIServices/eas-urn-service.git) |  | []() | 
+[PSIServices/eas-exodus-ws](https://github.com/PSIServices/eas-exodus-ws.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,4 +3,4 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [PSIServices/eas-healthchecks](https://github.com/PSIServices/eas-healthchecks.git) |  | []() | 
-[PSIServices/eas-candidate-attendance-service](https://github.com/PSIServices/eas-candidate-attendance-service.git) |  | []() | 
+[PSIServices/eas-urn-service](https://github.com/PSIServices/eas-urn-service.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -3,4 +3,4 @@
 Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [PSIServices/eas-healthchecks](https://github.com/PSIServices/eas-healthchecks.git) |  | []() | 
-[PSIServices/eas-selt-sqlserver](https://github.com/PSIServices/eas-selt-sqlserver.git) |  | []() | 
+[PSIServices/eas-parent-pom](https://github.com/PSIServices/eas-parent-pom.git) |  | []() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -5,3 +5,9 @@ dependencies:
   url: https://github.com/PSIServices/eas-healthchecks.git
   version: ""
   versionURL: ""
+- host: github.com
+  owner: PSIServices
+  repo: eas-selt-sqlserver
+  url: https://github.com/PSIServices/eas-selt-sqlserver.git
+  version: ""
+  versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -7,7 +7,7 @@ dependencies:
   versionURL: ""
 - host: github.com
   owner: PSIServices
-  repo: eas-candidate-attendance-service
-  url: https://github.com/PSIServices/eas-candidate-attendance-service.git
+  repo: eas-urn-service
+  url: https://github.com/PSIServices/eas-urn-service.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -7,7 +7,7 @@ dependencies:
   versionURL: ""
 - host: github.com
   owner: PSIServices
-  repo: eas-urn-service
-  url: https://github.com/PSIServices/eas-urn-service.git
+  repo: eas-exodus-ws
+  url: https://github.com/PSIServices/eas-exodus-ws.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -7,7 +7,7 @@ dependencies:
   versionURL: ""
 - host: github.com
   owner: PSIServices
-  repo: eas-selt-sqlserver
-  url: https://github.com/PSIServices/eas-selt-sqlserver.git
+  repo: eas-parent-pom
+  url: https://github.com/PSIServices/eas-parent-pom.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -7,7 +7,7 @@ dependencies:
   versionURL: ""
 - host: github.com
   owner: PSIServices
-  repo: eas-parent-pom
-  url: https://github.com/PSIServices/eas-parent-pom.git
+  repo: eas-candidate-attendance-service
+  url: https://github.com/PSIServices/eas-candidate-attendance-service.git
   version: ""
   versionURL: ""

--- a/repositories/templates/psiservices-eas-candidate-attendance-service-sr.yaml
+++ b/repositories/templates/psiservices-eas-candidate-attendance-service-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: PSIServices
+    provider: github
+    repository: eas-candidate-attendance-service
+  name: psiservices-eas-candidate-attendance-service
+spec:
+  description: Imported application for PSIServices/eas-candidate-attendance-service
+  httpCloneURL: https://github.com/PSIServices/eas-candidate-attendance-service.git
+  org: PSIServices
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: eas-candidate-attendance-service
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/PSIServices/eas-candidate-attendance-service.git

--- a/repositories/templates/psiservices-eas-exodus-ws-sr.yaml
+++ b/repositories/templates/psiservices-eas-exodus-ws-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: PSIServices
+    provider: github
+    repository: eas-exodus-ws
+  name: psiservices-eas-exodus-ws
+spec:
+  description: Imported application for PSIServices/eas-exodus-ws
+  httpCloneURL: https://github.com/PSIServices/eas-exodus-ws.git
+  org: PSIServices
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: eas-exodus-ws
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/PSIServices/eas-exodus-ws.git

--- a/repositories/templates/psiservices-eas-parent-pom-sr.yaml
+++ b/repositories/templates/psiservices-eas-parent-pom-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: PSIServices
+    provider: github
+    repository: eas-parent-pom
+  name: psiservices-eas-parent-pom
+spec:
+  description: Imported application for PSIServices/eas-parent-pom
+  httpCloneURL: https://github.com/PSIServices/eas-parent-pom.git
+  org: PSIServices
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: eas-parent-pom
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/PSIServices/eas-parent-pom.git

--- a/repositories/templates/psiservices-eas-selt-sqlserver-sr.yaml
+++ b/repositories/templates/psiservices-eas-selt-sqlserver-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: PSIServices
+    provider: github
+    repository: eas-selt-sqlserver
+  name: psiservices-eas-selt-sqlserver
+spec:
+  description: Imported application for PSIServices/eas-selt-sqlserver
+  httpCloneURL: https://github.com/PSIServices/eas-selt-sqlserver.git
+  org: PSIServices
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: eas-selt-sqlserver
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/PSIServices/eas-selt-sqlserver.git

--- a/repositories/templates/psiservices-eas-urn-service-sr.yaml
+++ b/repositories/templates/psiservices-eas-urn-service-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: PSIServices
+    provider: github
+    repository: eas-urn-service
+  name: psiservices-eas-urn-service
+spec:
+  description: Imported application for PSIServices/eas-urn-service
+  httpCloneURL: https://github.com/PSIServices/eas-urn-service.git
+  org: PSIServices
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: eas-urn-service
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/PSIServices/eas-urn-service.git


### PR DESCRIPTION
Update [PSIServices/eas-exodus-ws](https://github.com/PSIServices/eas-exodus-ws.git) 

Command run was `jx import -b --git-username=psiservices-tonywaters --name=eas-exodus-ws --url https://github.com/PSIServices/eas-exodus-ws.git --disable-updatebot --branches .* --no-draft`
<hr />

Update [PSIServices/eas-urn-service](https://github.com/PSIServices/eas-urn-service.git) 

Command run was `jx import -b --git-username=psiservices-tonywaters --name=eas-urn-service --url https://github.com/PSIServices/eas-urn-service.git --disable-updatebot --branches .* --no-draft`
<hr />

Update [PSIServices/eas-candidate-attendance-service](https://github.com/PSIServices/eas-candidate-attendance-service.git) 

Command run was `jx import -b --git-username=psiservices-tonywaters --name=eas-candidate-attendance-service --url https://github.com/PSIServices/eas-candidate-attendance-service.git --disable-updatebot --branches .* --no-draft`
<hr />

Update [PSIServices/eas-parent-pom](https://github.com/PSIServices/eas-parent-pom.git) 

Command run was `jx import -b --git-username=psiservices-tonywaters --name=eas-parent-pom --url https://github.com/PSIServices/eas-parent-pom.git --branches .* --no-draft`
<hr />

Update [PSIServices/eas-selt-sqlserver](https://github.com/PSIServices/eas-selt-sqlserver.git) 

Command run was `jx import -b --git-username=psiservices-tonywaters --name=eas-selt-sqlserver --url https://github.com/PSIServices/eas-selt-sqlserver.git --disable-updatebot --branches .* --no-draft`