### PR TITLE
chore(deps): bump dependency versions

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -4,4 +4,4 @@ Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [PSIServices/eas-healthchecks](https://github.com/PSIServices/eas-healthchecks.git) |  | []() | 
 [PSIServices/eas-urn-service](https://github.com/PSIServices/eas-urn-service.git) |  | []() | 
-[PSIServices/common-dropwizard](https://github.com/PSIServices/common-dropwizard.git) |  | []() | 
+[PSIServices/eas-results-service](https://github.com/PSIServices/eas-results-service.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -4,3 +4,4 @@ Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [PSIServices/eas-healthchecks](https://github.com/PSIServices/eas-healthchecks.git) |  | []() | 
 [PSIServices/eas-urn-service](https://github.com/PSIServices/eas-urn-service.git) |  | []() | 
+[PSIServices/eas-exodus-admin](https://github.com/PSIServices/eas-exodus-admin.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -4,4 +4,4 @@ Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [PSIServices/eas-healthchecks](https://github.com/PSIServices/eas-healthchecks.git) |  | []() | 
 [PSIServices/eas-urn-service](https://github.com/PSIServices/eas-urn-service.git) |  | []() | 
-[PSIServices/eas-exodus-admin](https://github.com/PSIServices/eas-exodus-admin.git) |  | []() | 
+[PSIServices/common-dropwizard](https://github.com/PSIServices/common-dropwizard.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -4,4 +4,4 @@ Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [PSIServices/eas-healthchecks](https://github.com/PSIServices/eas-healthchecks.git) |  | []() | 
 [PSIServices/eas-urn-service](https://github.com/PSIServices/eas-urn-service.git) |  | []() | 
-[PSIServices/eas-results-service](https://github.com/PSIServices/eas-results-service.git) |  | []() | 
+[PSIServices/geneses](https://github.com/PSIServices/geneses.git) |  | []() | 

--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -4,4 +4,4 @@ Dependency | Sources | Version | Mismatched versions
 ---------- | ------- | ------- | -------------------
 [PSIServices/eas-healthchecks](https://github.com/PSIServices/eas-healthchecks.git) |  | []() | 
 [PSIServices/eas-urn-service](https://github.com/PSIServices/eas-urn-service.git) |  | []() | 
-[PSIServices/geneses](https://github.com/PSIServices/geneses.git) |  | []() | 
+[PSIServices/smartpay-stub](https://github.com/PSIServices/smartpay-stub.git) |  | []() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -13,7 +13,7 @@ dependencies:
   versionURL: ""
 - host: github.com
   owner: PSIServices
-  repo: eas-results-service
-  url: https://github.com/PSIServices/eas-results-service.git
+  repo: geneses
+  url: https://github.com/PSIServices/geneses.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -13,7 +13,7 @@ dependencies:
   versionURL: ""
 - host: github.com
   owner: PSIServices
-  repo: common-dropwizard
-  url: https://github.com/PSIServices/common-dropwizard.git
+  repo: eas-results-service
+  url: https://github.com/PSIServices/eas-results-service.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -13,7 +13,7 @@ dependencies:
   versionURL: ""
 - host: github.com
   owner: PSIServices
-  repo: geneses
-  url: https://github.com/PSIServices/geneses.git
+  repo: smartpay-stub
+  url: https://github.com/PSIServices/smartpay-stub.git
   version: ""
   versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -11,3 +11,9 @@ dependencies:
   url: https://github.com/PSIServices/eas-urn-service.git
   version: ""
   versionURL: ""
+- host: github.com
+  owner: PSIServices
+  repo: eas-exodus-admin
+  url: https://github.com/PSIServices/eas-exodus-admin.git
+  version: ""
+  versionURL: ""

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -13,7 +13,7 @@ dependencies:
   versionURL: ""
 - host: github.com
   owner: PSIServices
-  repo: eas-exodus-admin
-  url: https://github.com/PSIServices/eas-exodus-admin.git
+  repo: common-dropwizard
+  url: https://github.com/PSIServices/common-dropwizard.git
   version: ""
   versionURL: ""

--- a/repositories/templates/psiservices-common-dropwizard-sr.yaml
+++ b/repositories/templates/psiservices-common-dropwizard-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: PSIServices
+    provider: github
+    repository: common-dropwizard
+  name: psiservices-common-dropwizard
+spec:
+  description: Imported application for PSIServices/common-dropwizard
+  httpCloneURL: https://github.com/PSIServices/common-dropwizard.git
+  org: PSIServices
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: common-dropwizard
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/PSIServices/common-dropwizard.git

--- a/repositories/templates/psiservices-eas-exodus-admin-sr.yaml
+++ b/repositories/templates/psiservices-eas-exodus-admin-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: PSIServices
+    provider: github
+    repository: eas-exodus-admin
+  name: psiservices-eas-exodus-admin
+spec:
+  description: Imported application for PSIServices/eas-exodus-admin
+  httpCloneURL: https://github.com/PSIServices/eas-exodus-admin.git
+  org: PSIServices
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: eas-exodus-admin
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/PSIServices/eas-exodus-admin.git

--- a/repositories/templates/psiservices-eas-results-service-sr.yaml
+++ b/repositories/templates/psiservices-eas-results-service-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: PSIServices
+    provider: github
+    repository: eas-results-service
+  name: psiservices-eas-results-service
+spec:
+  description: Imported application for PSIServices/eas-results-service
+  httpCloneURL: https://github.com/PSIServices/eas-results-service.git
+  org: PSIServices
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: eas-results-service
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/PSIServices/eas-results-service.git

--- a/repositories/templates/psiservices-geneses-sr.yaml
+++ b/repositories/templates/psiservices-geneses-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: PSIServices
+    provider: github
+    repository: geneses
+  name: psiservices-geneses
+spec:
+  description: Imported application for PSIServices/geneses
+  httpCloneURL: https://github.com/PSIServices/geneses.git
+  org: PSIServices
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: geneses
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/PSIServices/geneses.git

--- a/repositories/templates/psiservices-smartpay-stub-sr.yaml
+++ b/repositories/templates/psiservices-smartpay-stub-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: PSIServices
+    provider: github
+    repository: smartpay-stub
+  name: psiservices-smartpay-stub
+spec:
+  description: Imported application for PSIServices/smartpay-stub
+  httpCloneURL: https://github.com/PSIServices/smartpay-stub.git
+  org: PSIServices
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: smartpay-stub
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/PSIServices/smartpay-stub.git


### PR DESCRIPTION
Update [PSIServices/smartpay-stub](https://github.com/PSIServices/smartpay-stub.git) 

Command run was `jx import -b --git-username=psiservices-tonywaters --name=eas-smartpay-stub --url https://github.com/PSIServices/smartpay-stub.git --disable-updatebot --branches .* --no-draft`
<hr />

Update [PSIServices/geneses](https://github.com/PSIServices/geneses.git) 

Command run was `jx import -b --git-username=psiservices-tonywaters --name=eas-geneses --url https://github.com/PSIServices/geneses.git --disable-updatebot --branches .* --no-draft`
<hr />

Update [PSIServices/eas-results-service](https://github.com/PSIServices/eas-results-service.git) 

Command run was `jx import -b --git-username=psiservices-tonywaters --name=eas-results-service --url https://github.com/PSIServices/eas-results-service.git --disable-updatebot --branches .* --no-draft`
<hr />

Update [PSIServices/common-dropwizard](https://github.com/PSIServices/common-dropwizard.git) 

Command run was `jx import -b --git-username=psiservices-tonywaters --name=common-dropwizard --url https://github.com/PSIServices/common-dropwizard.git --disable-updatebot --branches .* --no-draft`
<hr />

Update [PSIServices/eas-exodus-admin](https://github.com/PSIServices/eas-exodus-admin.git) 

Command run was `jx import -b --git-username=psiservices-tonywaters --name=eas-exodus-admin --url https://github.com/PSIServices/eas-exodus-admin.git --disable-updatebot --branches .* --no-draft`