### PR TITLE
chore(deps): bump https://github.com/PSIServices/eas-geocoder-stub.git 

### DIFF
--- a/dependency-matrix/matrix.md
+++ b/dependency-matrix/matrix.md
@@ -16,3 +16,4 @@ Dependency | Sources | Version | Mismatched versions
 [PSIServices/eas-payeezy-stub](https://github.com/PSIServices/eas-payeezy-stub.git) |  | []() | 
 [PSIServices/eas-mailhog](https://github.com/PSIServices/eas-mailhog.git) |  | []() | 
 [psiservices-tonywaters/et2-stub](https://github.com/psiservices-tonywaters/et2-stub.git) |  | []() | 
+[PSIServices/eas-geocoder-stub](https://github.com/PSIServices/eas-geocoder-stub.git) |  | []() | 

--- a/dependency-matrix/matrix.yaml
+++ b/dependency-matrix/matrix.yaml
@@ -83,3 +83,9 @@ dependencies:
   url: https://github.com/psiservices-tonywaters/et2-stub.git
   version: ""
   versionURL: ""
+- host: github.com
+  owner: PSIServices
+  repo: eas-geocoder-stub
+  url: https://github.com/PSIServices/eas-geocoder-stub.git
+  version: ""
+  versionURL: ""

--- a/repositories/templates/psiservices-eas-geocoder-stub-sr.yaml
+++ b/repositories/templates/psiservices-eas-geocoder-stub-sr.yaml
@@ -1,0 +1,21 @@
+apiVersion: jenkins.io/v1
+kind: SourceRepository
+metadata:
+  creationTimestamp: null
+  labels:
+    owner: PSIServices
+    provider: github
+    repository: eas-geocoder-stub
+  name: psiservices-eas-geocoder-stub
+spec:
+  description: Imported application for PSIServices/eas-geocoder-stub
+  httpCloneURL: https://github.com/PSIServices/eas-geocoder-stub.git
+  org: PSIServices
+  provider: https://github.com
+  providerKind: github
+  providerName: github
+  repo: eas-geocoder-stub
+  scheduler:
+    kind: ""
+    name: ""
+  url: https://github.com/PSIServices/eas-geocoder-stub.git


### PR DESCRIPTION
Update [PSIServices/eas-geocoder-stub](https://github.com/PSIServices/eas-geocoder-stub.git) 

Command run was `jx import -b --git-username=psiservices-tonywaters --name=eas-geocoder-stub --url https://github.com/PSIServices/eas-geocoder-stub.git --disable-updatebot --branches .* --no-draft`